### PR TITLE
Fix typo in `createOriented` example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ var normalStyles = ResponsiveStylesheet.create({
 	}
 });
 
-var responsiveStyles = ResponsiveStylesheet.createcreateOriented({
+var responsiveStyles = ResponsiveStylesheet.createOriented({
 	landscape: {
 		item: {
 			marginHorizontal: 16


### PR DESCRIPTION
This fixes a typo in the `createOriented` example in the readme.