### PR TITLE
Add min and max-direction to use smallest direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Creates a responsive stylesheet based size increments or decrements (like media 
 
 `direction` is one of "min-width", "max-width", "min-height", "max-height", "min-direction" or "max-direction". It's purpose is to determine whether the `size` represents the `width` or `height`, and whether you should look for `size` values higher or greater than the current screen resolution.
 
-* min/max-direction uses the smallest direction, height or width.
+* min/max-direction uses the smallest direction value, `height` or `width`.
 
 The return value is a special kind of stylesheet where when you try to get a style, you will get back an array of all styles that are valid for the current resolution. Check the examples for details.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Creates a responsive stylesheet based size increments or decrements (like media 
 
 `map` is an object literal mapping of `{size: obj}` where `size` is an integer representing pixels, and `obj` is a style definition to use with `.create(obj)`
 
-`direction` is one of "min-width", "max-width", "min-height", or "max-height". It's purpose is to determine whether the `size` represents the `width` or `height`, and whether you should look for `size` values higher or greater than the current screen resolution.
+`direction` is one of "min-width", "max-width", "min-height", "max-height", "min-direction" or "max-direction". It's purpose is to determine whether the `size` represents the `width` or `height`, and whether you should look for `size` values higher or greater than the current screen resolution.
+
+* min/max-direction uses the smallest direction, height or width.
 
 The return value is a special kind of stylesheet where when you try to get a style, you will get back an array of all styles that are valid for the current resolution. Check the examples for details.
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ var VALID_direction = [
 	"min-width",
 	"max-width",
 	"min-height",
-	"max-height"
+	"max-height",
+	"min-direction",
+	"max-direction"
 ];
 
 module.exports = {
@@ -98,9 +100,15 @@ function createOriented(map) {
 
 function validSizes(direction, sizes) {
 	var dimensions = Dimensions.get("window");
+	var width = dimensions.width;
+	var height = dimensions.height;
 
 	var dimensionName = direction.slice(4);
-	var dimension = dimensions[dimensionName];
+	var dimension;
+	if(dimensionName === "direction")
+		dimension = width <= height ? width : height
+	else
+		dimension = dimensions[dimensionName];
 
 	var directionName = direction.slice(0, 3);
 	var greater = directionName === "min";


### PR DESCRIPTION
Basically when the phone orients to landscape or portrait the orientation changes the width to be the same size as a small tablet causing weird UI behaviour. This PR adds a new valid direction to use the smallest of the two width or height, so that when the orientation changes, it will continue using the 0 style.